### PR TITLE
Add hyperloop plugin and .gitignore for Cursor files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,7 @@
   },
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true,
-    "code-review@claude-plugins-official": true
+    "code-review@claude-plugins-official": true,
+    "hyperloop@hyper-plugs": true
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore
+
+# Hyperplugs:Hyperloop
+/plans


### PR DESCRIPTION
Enable the hyperloop plugin in settings and create a .gitignore file for Cursor-related files to improve project management.