### PR TITLE
feat(adr-wizard): close authoring guidance and validation quality gaps

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,7 @@
     "agent-sdk-dev@claude-plugins-official": true,
     "adr-wizard@hyper-plugs": true,
     "explanatory-output-style@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true
+    "claude-md-management@claude-plugins-official": true,
+    "plugin-dev@claude-plugins-official": true
   }
 }

--- a/adr-wizard/.claude-plugin/plugin.json
+++ b/adr-wizard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adr-wizard",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ADR lifecycle management for Claude Code. Create, supersede, deprecate, and validate Architecture Decision Records across multiple directories using a CLAUDE.md convention for ADR location discovery.",
   "author": {
     "name": "Sam Romano",

--- a/adr-wizard/CHANGELOG.md
+++ b/adr-wizard/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to the `adr-wizard` plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-03-28
+
+### Added
+
+- `adr-check` scoped mode — invoke with a file path argument
+  (`/adr-check path/to/NNNN-adr-file.md`) to validate only that file; runs structural and style
+  checks only, skipping index sync, cross-reference checks, and diff-based warnings
+- `adr-check` style check (Check 2.1e) — uses model judgment to assess whether the
+  `## Consequences` section contains at least one genuinely adverse consequence or trade-off;
+  emits an advisory style warning (not a structural failure) when none is found
+- `adr-check` Style Warnings report section — distinct from Diff-Based Warnings; appears only
+  when style checks fire; does not affect the pass/fail result
+- `adr-check` `argument-hint` front-matter field for optional scoped file path
+- `adr-check` contract updated with scoped mode interface, Section 1.2, style check subsection
+  2.1e, Style Warnings report format, and scoped mode pass/fail semantics rows
+- `adr-create` Step 0 — decision worthiness evaluation with qualifying signals, detection
+  heuristics, explicit skip cases, and `AskUserQuestion` confirmation before proceeding
+- `adr-create` per-section writing quality criteria in Step 5 — Context (problem not solution,
+  no advocacy), Decision (active voice, declarative, avoid passive constructions), Consequences
+  (must include at least one adverse consequence; 200–400 word target)
+- `adr-create` PR co-location reminder in Step 8 — advises committing the ADR in the same PR
+  as the code it describes for traceability
+- `adr-create` Step 9 — post-write validation; invokes `adr-check` in scoped mode against the
+  newly created file; blocks on structural FAIL, surfaces style warnings without blocking
+- `adr-supersede` and `adr-deprecate` additive-only principle notes near the top of each skill
+- `adr-supersede` Step 10 and `adr-deprecate` Step 8 — post-write validation; invokes
+  `adr-check` in scoped mode against the modified ADR; blocks on structural FAIL, surfaces style
+  warnings without blocking
+
 ## [1.0.0] - 2026-03-27
 
 ### Added

--- a/adr-wizard/README.md
+++ b/adr-wizard/README.md
@@ -33,12 +33,12 @@ claude plugin install adr-wizard@hyper-plugs
 
 ## Skills<a name="skills"></a>
 
-| Skill           | Command          | Description                                                    |
-| --------------- | ---------------- | -------------------------------------------------------------- |
-| `adr-create`    | `/adr-create`    | Create a new ADR with auto-numbering and index updates         |
-| `adr-supersede` | `/adr-supersede` | Supersede an existing ADR, with bidirectional cross-references |
-| `adr-deprecate` | `/adr-deprecate` | Deprecate an ADR with a recorded reason                        |
-| `adr-check`     | `/adr-check`     | Validate all ADRs for structural integrity and index sync      |
+| Skill           | Command             | Description                                                                                                     |
+| --------------- | ------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `adr-create`    | `/adr-create`       | Create a new ADR with auto-numbering and index updates                                                          |
+| `adr-supersede` | `/adr-supersede`    | Supersede an existing ADR, with bidirectional cross-references                                                  |
+| `adr-deprecate` | `/adr-deprecate`    | Deprecate an ADR with a recorded reason                                                                         |
+| `adr-check`     | `/adr-check [file]` | Validate ADRs for structural integrity, index sync, and advisory style checks; supports scoped single-file mode |
 
 ### adr-create<a name="adr-create"></a>
 
@@ -56,9 +56,13 @@ context, and updates the directory index. If no ADR directory exists, offers to 
 # create an ADR automatically based on what you've described.
 ```
 
-The skill discovers your ADR directory from CLAUDE.md, finds the next available number, and
-writes `NNNN-<slug>.md` with Context, Decision, and Consequences drafted from your conversation.
-It interviews you via `AskUserQuestion` only for details it cannot infer.
+The skill first evaluates whether the decision warrants an ADR (four qualifying signals: cross-cutting
+concern, non-obvious to a new contributor, costly to reverse, or multiple alternatives considered).
+If no signal applies it will ask for confirmation before proceeding. It then discovers your ADR
+directory from CLAUDE.md, finds the next available number, and writes `NNNN-<slug>.md` with
+Context, Decision, and Consequences drafted from your conversation. It interviews you via
+`AskUserQuestion` only for details it cannot infer. After writing the file it runs `/adr-check`
+in scoped mode to validate the new ADR and surfaces any issues before confirming completion.
 
 ### adr-supersede<a name="adr-supersede"></a>
 
@@ -93,14 +97,20 @@ future readers understand what changed and why.
 
 Validates all ADR directories for structural integrity, index sync, and cross-reference
 consistency. Also scans `git diff` for patterns that may indicate undocumented architectural
-decisions (advisory warnings only).
+decisions (advisory warnings only). Emits advisory style warnings when the `## Consequences`
+section of an ADR contains no clearly adverse consequence or trade-off.
 
 ```
+# Whole-directory mode — validates all ADR directories
 /adr-check
+
+# Scoped mode — validates a single file only (structural + style checks; skips index/cross-ref/diff)
+/adr-check path/to/NNNN-adr-file.md
 ```
 
 Exit result: **PASS** (all checks clear) or **FAIL** (with a remediation report listing exactly
-what needs fixing and in which files).
+what needs fixing and in which files). Style warnings are advisory only and do not affect the
+pass/fail result.
 
 ## ADR Location Convention<a name="adr-location-convention"></a>
 

--- a/adr-wizard/skills/adr-check/SKILL.md
+++ b/adr-wizard/skills/adr-check/SKILL.md
@@ -1,43 +1,50 @@
 ---
 name: adr-check
-description: "Validate that all Architecture Decision Records (ADRs) are in sync with the codebase — checks ADR structure, status fields, index consistency, and cross-references. Surfaces git-diff-based warnings for undocumented architectural decisions. Invocable via /adr-check or by gate agents performing ADR validation."
+description: "Validate Architecture Decision Records (ADRs) for structural integrity, index sync, cross-references, and advisory style quality. Supports Global mode (all ADR directories + diff-based warnings), Scoped mode (single file, directory, or natural-language query — no diff noise), and future Diff mode. Invocable via /adr-check or by lifecycle skills and gate agents."
 user-invocable: true
-argument-hint: "[optional: path/to/NNNN-adr-file.md]"
+argument-hint: "[optional: path/to/NNNN-adr-file.md | path/to/adrs/ | natural language query]"
 ---
 
 # adr-check
 
-Validates all ADR directories against the contract defined in
-`references/adr-check-contract.md`. Outputs a structured pass/fail report per directory, plus
-advisory diff-based warnings.
+Validates ADRs against the contract defined in `references/adr-check-contract.md`. Supports
+three modes: **Global** (all discovered ADR directories, including diff-based warnings),
+**Scoped** (a single file, a directory, or a natural-language query — no diff-based noise), and
+future **Diff** mode (ADRs changed in the current branch). Outputs a structured pass/fail report
+with a consistent header regardless of mode.
 
 ---
 
 ## Step 1 — Determine mode and discover inputs
 
-1. Inspect the skill argument (the text following `/adr-check`, if any).
-   - If the argument is a path to a `.md` file (e.g., `/adr-check docs/adrs/0001-foo.md`):
-     - Set `scoped_mode = true` and `scoped_file = <argument path>`.
-     - Skip the directory discovery steps below. Proceed directly to Step 2 using only
-       `scoped_file` as the target. Check 2.2, Check 2.3, and Step 4 are skipped entirely.
-   - Otherwise: set `scoped_mode = false` and continue with directory discovery.
+1. Inspect the skill argument (the text following `/adr-check`, if any):
 
-2. *(whole-directory mode only)* Read the project's `CLAUDE.md`.
-3. *(whole-directory mode only)* Search for any heading containing `ADR Locations`
+   - **No argument** → `mode = global`. Continue with directory discovery (steps 2–6).
+
+   - **Argument resolves to a `.md` file** → `mode = scoped_file`, `target = <path>`.
+     Skip directory discovery. Proceed to Step 2 with only that file as target.
+     Checks 2.2, 2.3, and Step 4 are skipped entirely.
+
+   - **Argument resolves to a directory** → `mode = scoped_dir`, `target = <directory>`.
+     Skip CLAUDE.md discovery. Use `target` as the sole entry in `adr_dirs`.
+     Run Checks 2.1, 2.1e, 2.2, and 2.3 for that directory. Skip Step 4.
+
+   - **Any other non-empty argument** → `mode = scoped_query`, `query = <argument>`.
+     Run directory discovery (steps 2–6) to locate all ADR files. Then use model judgment
+     to identify which ADR files match the natural-language query. Use those files as the
+     validation target. Run only Checks 2.1 and 2.1e against each matched file. Skip 2.2,
+     2.3, and Step 4. If no ADRs match the query, emit an advisory warning and exit PASS.
+
+2. *(global and scoped_query only)* Read the project's `CLAUDE.md`.
+3. *(global and scoped_query only)* Search for any heading containing `ADR Locations`
    (case-insensitive, any heading level).
-4. *(whole-directory mode only)* If found, collect each bullet list item as a relative path,
+4. *(global and scoped_query only)* If found, collect each bullet list item as a relative path,
    stripping inline `# comments`. Store as `adr_dirs`.
-5. *(whole-directory mode only)* If not found, fall back: scan the repository root for
+5. *(global and scoped_query only)* If not found, fall back: scan the repository root for
    `docs/adrs/`, `decisions/`, and `architecture/decisions/`. Use whichever exist.
-6. *(whole-directory mode only)* If `adr_dirs` is empty after both methods, output:
-   ```
-   ADR Check Report
-   ================
-   WARNING: No ADR directories found. Skipping validation.
-
-   Overall: PASS
-   ```
-   Stop. (No ADR directories is not a failure — nothing to validate.)
+6. *(global only)* If `adr_dirs` is empty after both methods, output a report with
+   `Mode: Global` and emit: `WARNING: No ADR directories found. Skipping validation.`
+   Set `Overall: PASS` and stop.
 
 ## Step 2 — Validate each directory
 
@@ -96,38 +103,34 @@ For each directory in `adr_dirs`, run all checks below. Track failures as a list
 
 ## Step 3 — Build the validation report
 
-**Whole-directory mode:** For each directory in `adr_dirs`:
-- If `issues` is empty: status = PASS
-- If `issues` is non-empty: status = FAIL
+Separate all items collected from Check 2.1e into a `style_warnings` list. These are NOT counted
+as structural issues and do NOT affect status.
 
-**Scoped mode:** Evaluate only `scoped_file`. If structural issues (2.1a–2.1d) are present,
-status = FAIL. Style warnings (2.1e) do not affect status.
+For each validated target (directory or file):
+- If structural issues (2.1a–2.1d) are present: status = FAIL
+- Otherwise: status = PASS
 
-Separate the collected items from Check 2.1e into a `style_warnings` list. These are NOT counted
-as issues and do NOT affect status.
-
-Output:
+Output the report using the structure below. The header rows (`Mode`, `Target`, `ADRs`) are
+**always present** regardless of mode — they provide context for all rows that follow.
 
 ```
 ADR Check Report
 ================
 
-Directory: <path>          ← whole-directory mode
+Mode:    Global | Scoped (file) | Scoped (directory) | Scoped (query)
+Target:  <path, directory, or natural-language query>
+ADRs:    <comma-separated list of all validated ADR filenames>
+
+Results
+-------
+<path/to/directory-or-file>:
   Status: PASS | FAIL
   Issues:
-    - <issue 1>
-    - <issue 2>
-    ...
+    - [ADR-NNNN] <issue description>
 
-Directory: <path>
+<path/to/next-item>:
   Status: PASS
   Issues: none
-
-File: <path>               ← scoped mode
-  Status: PASS | FAIL
-  Issues:
-    - <issue 1>
-    ...
 
 Style Warnings (advisory only — not gate-blocking)
 ===================================================
@@ -136,14 +139,17 @@ Style Warnings (advisory only — not gate-blocking)
 Overall: PASS | FAIL
 ```
 
+**Results grouping:** In `global` and `scoped_dir` modes, group results by directory path. In
+`scoped_file` and `scoped_query` modes, list each validated file as its own result entry.
+
 The `Style Warnings` section appears only when `style_warnings` is non-empty; omit it otherwise.
 
-If any directory (or the scoped file) has status FAIL, `Overall` is FAIL. Otherwise PASS.
+If any result entry has status FAIL, `Overall` is FAIL. Otherwise PASS.
 
 On FAIL, append a `Remediation` section listing each issue with the specific file and the action
 needed to fix it.
 
-## Step 4 — Diff-based warnings *(whole-directory mode only; skip in scoped mode)*
+## Step 4 — Diff-based warnings *(Global mode only — skip in all scoped sub-modes)*
 
 1. Run `git diff HEAD` to capture staged + unstaged changes.
 2. Scan the diff output for these patterns:

--- a/adr-wizard/skills/adr-check/SKILL.md
+++ b/adr-wizard/skills/adr-check/SKILL.md
@@ -2,6 +2,7 @@
 name: adr-check
 description: "Validate that all Architecture Decision Records (ADRs) are in sync with the codebase — checks ADR structure, status fields, index consistency, and cross-references. Surfaces git-diff-based warnings for undocumented architectural decisions. Invocable via /adr-check or by gate agents performing ADR validation."
 user-invocable: true
+argument-hint: "[optional: path/to/NNNN-adr-file.md]"
 ---
 
 # adr-check
@@ -12,15 +13,23 @@ advisory diff-based warnings.
 
 ---
 
-## Step 1 — Discover ADR directories
+## Step 1 — Determine mode and discover inputs
 
-1. Read the project's `CLAUDE.md`.
-2. Search for any heading containing `ADR Locations` (case-insensitive, any heading level).
-3. If found, collect each bullet list item as a relative path, stripping inline `# comments`.
-   Store as `adr_dirs`.
-4. If not found, fall back: scan the repository root for `docs/adrs/`, `decisions/`, and
-   `architecture/decisions/`. Use whichever exist.
-5. If `adr_dirs` is empty after both methods, output:
+1. Inspect the skill argument (the text following `/adr-check`, if any).
+   - If the argument is a path to a `.md` file (e.g., `/adr-check docs/adrs/0001-foo.md`):
+     - Set `scoped_mode = true` and `scoped_file = <argument path>`.
+     - Skip the directory discovery steps below. Proceed directly to Step 2 using only
+       `scoped_file` as the target. Check 2.2, Check 2.3, and Step 4 are skipped entirely.
+   - Otherwise: set `scoped_mode = false` and continue with directory discovery.
+
+2. *(whole-directory mode only)* Read the project's `CLAUDE.md`.
+3. *(whole-directory mode only)* Search for any heading containing `ADR Locations`
+   (case-insensitive, any heading level).
+4. *(whole-directory mode only)* If found, collect each bullet list item as a relative path,
+   stripping inline `# comments`. Store as `adr_dirs`.
+5. *(whole-directory mode only)* If not found, fall back: scan the repository root for
+   `docs/adrs/`, `decisions/`, and `architecture/decisions/`. Use whichever exist.
+6. *(whole-directory mode only)* If `adr_dirs` is empty after both methods, output:
    ```
    ADR Check Report
    ================
@@ -51,8 +60,16 @@ For each directory in `adr_dirs`, run all checks below. Track failures as a list
    d. **Consequences present:** The file contains a `## Consequences` section. Content may be
       brief. If entirely absent, add issue:
       `[ADR-NNNN] ## Consequences section is missing`
+   e. **Consequences quality (style check):** Using model judgment — not keyword matching —
+      assess whether the `## Consequences` section contains at least one genuinely adverse
+      outcome. Qualifying examples: a known risk, a trade-off, a migration cost, an increase in
+      complexity, a performance regression, reduced flexibility, or an explicit statement of what
+      is being given up. If no such adverse consequence is found, add a **style warning** (not a
+      structural issue):
+      `[ADR-NNNN] Consequences section contains no clearly adverse consequence or trade-off — consider adding one for credibility`
+      Style warnings do not affect the pass/fail result and are reported separately (see Step 3).
 
-### Check 2.2 — Index sync
+### Check 2.2 — Index sync *(whole-directory mode only)*
 
 1. Check if `<dir>/README.md` exists.
    - If it does not exist, add issue: `README.md index is missing from <dir>`
@@ -63,7 +80,7 @@ For each directory in `adr_dirs`, run all checks below. Track failures as a list
 4. For each entry in the README.md table, check the referenced ADR file exists. If not, add
    issue: `[index entry] README.md references <filename> but file does not exist (orphaned entry)`
 
-### Check 2.3 — Cross-reference integrity
+### Check 2.3 — Cross-reference integrity *(whole-directory mode only)*
 
 1. For each ADR file with a status of `Superseded by ADR-NNNN`:
    a. Verify `NNNN-*.md` exists in the directory. If not, add issue:
@@ -79,9 +96,15 @@ For each directory in `adr_dirs`, run all checks below. Track failures as a list
 
 ## Step 3 — Build the validation report
 
-For each directory in `adr_dirs`:
+**Whole-directory mode:** For each directory in `adr_dirs`:
 - If `issues` is empty: status = PASS
 - If `issues` is non-empty: status = FAIL
+
+**Scoped mode:** Evaluate only `scoped_file`. If structural issues (2.1a–2.1d) are present,
+status = FAIL. Style warnings (2.1e) do not affect status.
+
+Separate the collected items from Check 2.1e into a `style_warnings` list. These are NOT counted
+as issues and do NOT affect status.
 
 Output:
 
@@ -89,7 +112,7 @@ Output:
 ADR Check Report
 ================
 
-Directory: <path>
+Directory: <path>          ← whole-directory mode
   Status: PASS | FAIL
   Issues:
     - <issue 1>
@@ -100,15 +123,27 @@ Directory: <path>
   Status: PASS
   Issues: none
 
+File: <path>               ← scoped mode
+  Status: PASS | FAIL
+  Issues:
+    - <issue 1>
+    ...
+
+Style Warnings (advisory only — not gate-blocking)
+===================================================
+  - [ADR-NNNN] <style warning message>
+
 Overall: PASS | FAIL
 ```
 
-If any directory has status FAIL, `Overall` is FAIL. Otherwise PASS.
+The `Style Warnings` section appears only when `style_warnings` is non-empty; omit it otherwise.
+
+If any directory (or the scoped file) has status FAIL, `Overall` is FAIL. Otherwise PASS.
 
 On FAIL, append a `Remediation` section listing each issue with the specific file and the action
 needed to fix it.
 
-## Step 4 — Diff-based warnings (advisory only)
+## Step 4 — Diff-based warnings *(whole-directory mode only; skip in scoped mode)*
 
 1. Run `git diff HEAD` to capture staged + unstaged changes.
 2. Scan the diff output for these patterns:
@@ -134,5 +169,6 @@ needed to fix it.
 
 Print the full report. The overall result determines the exit signal to callers:
 
-- **PASS** (with or without warnings): success. Gate consumers should continue.
+- **PASS** (with or without diff-based warnings or style warnings): success. Gate consumers
+  should continue.
 - **FAIL**: failure. Gate consumers should block and present the remediation steps to the user.

--- a/adr-wizard/skills/adr-check/SKILL.md
+++ b/adr-wizard/skills/adr-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adr-check
-description: "Validate Architecture Decision Records (ADRs) for structural integrity, index sync, cross-references, and advisory style quality. Supports Global mode (all ADR directories + diff-based warnings), Scoped mode (single file, directory, or natural-language query — no diff noise), and future Diff mode. Invocable via /adr-check or by lifecycle skills and gate agents."
+description: "This skill should be used when the user asks to 'validate ADRs', 'check ADR structure', 'run adr-check', 'check for undocumented decisions', or when lifecycle skills and gate agents need to validate ADR files. Supports Global mode (all discovered ADR directories, including diff-based warnings), Scoped mode (single file, directory, or natural-language query — no diff noise), and future Diff mode."
 user-invocable: true
 argument-hint: "[optional: path/to/NNNN-adr-file.md | path/to/adrs/ | natural language query]"
 ---
@@ -181,3 +181,7 @@ Print the full report. The overall result determines the exit signal to callers:
 - **PASS** (with or without diff-based warnings or style warnings): success. Gate consumers
   should continue.
 - **FAIL**: failure. Gate consumers should block and present the remediation steps to the user.
+
+## Additional Resources
+
+- **`references/adr-check-contract.md`** — Full contract specification: discovery rules, validation checks (2.1–2.3, 2.1e), report format, pass/fail semantics, and invocation modes.

--- a/adr-wizard/skills/adr-check/SKILL.md
+++ b/adr-wizard/skills/adr-check/SKILL.md
@@ -8,10 +8,13 @@ argument-hint: "[optional: path/to/NNNN-adr-file.md | path/to/adrs/ | natural la
 # adr-check
 
 Validates ADRs against the contract defined in `references/adr-check-contract.md`. Supports
-three modes: **Global** (all discovered ADR directories, including diff-based warnings),
-**Scoped** (a single file, a directory, or a natural-language query — no diff-based noise), and
-future **Diff** mode (ADRs changed in the current branch). Outputs a structured pass/fail report
-with a consistent header regardless of mode.
+three modes:
+
+* **Global** (all discovered ADR directories, including diff-based warnings),
+* **Scoped** (a single file, a directory, or a natural-language query — no diff-based noise), and
+* **Diff** (ADRs changed in the current branch).
+
+Outputs a structured pass/fail report with a consistent header, regardless of mode.
 
 ---
 

--- a/adr-wizard/skills/adr-check/references/adr-check-contract.md
+++ b/adr-wizard/skills/adr-check/references/adr-check-contract.md
@@ -9,6 +9,8 @@ validator for a gate.
 
 ## 1. Discovery — Inputs
 
+### 1.1 Whole-Directory Mode (default)
+
 The skill MUST discover ADR directories using the following priority order:
 
 1. **CLAUDE.md convention (primary):** Search the project's `CLAUDE.md` for any heading
@@ -29,6 +31,21 @@ If no ADR directories are found via either method, the skill MUST report this as
 (not a failure) and exit with a passing result. A project with no ADR directories has nothing to
 validate.
 
+### 1.2 Scoped Mode
+
+When the skill is invoked with a file path argument (e.g., `/adr-check docs/adrs/0001-foo.md`),
+it enters **scoped mode**:
+
+- Only the specified file is validated.
+- Only structural checks (Section 2.1) and style checks (Section 2.1e) run against that file.
+- Section 2.2 (Index Sync) and Section 2.3 (Cross-Reference Integrity) are skipped.
+- Section 4 (Diff-Based Warnings) is skipped entirely.
+- The report scope is limited to the single file rather than a directory.
+
+Scoped mode is designed for use by lifecycle skills (`adr-create`, `adr-supersede`,
+`adr-deprecate`) that need to validate only the file they just wrote, without noise from
+unrelated ADRs or diff patterns.
+
 ---
 
 ## 2. Validation — What Is Checked
@@ -45,6 +62,24 @@ an ADR file. For each ADR file, verify:
   or placeholder text like "TODO").
 - The file contains a `## Decision` section with non-trivial content.
 - The file contains a `## Consequences` section (may be brief; existence is sufficient).
+
+### 2.1e Style Check — Consequences Quality
+
+This check fires on every validated ADR file (in both whole-directory and scoped mode).
+
+The skill uses model judgment — not keyword matching — to assess whether the `## Consequences`
+section contains at least one genuinely adverse outcome. Qualifying examples include: a known
+risk, a trade-off, a migration cost, an increase in complexity, a performance regression, reduced
+flexibility, or an explicit statement of what is being given up.
+
+If no such adverse consequence is found, the skill emits a **style warning** (not a structural
+failure):
+
+```
+[ADR-NNNN] Consequences section contains no clearly adverse consequence or trade-off — consider adding one for credibility
+```
+
+Style warnings are informational. They do not affect the pass/fail result.
 
 ### 2.2 Index Sync
 
@@ -86,6 +121,10 @@ Directory: <path>
   Status: PASS
   Issues: none
 
+Style Warnings (advisory only — not gate-blocking)
+===================================================
+  - [ADR-NNNN] <style warning message>
+
 Overall: PASS | FAIL
 ```
 
@@ -93,6 +132,11 @@ On failure, each issue entry MUST include:
 - Which ADR file is affected (by number and filename)
 - What check failed
 - A specific remediation step (e.g., "Add a non-empty ## Context section to docs/adrs/003-foo.md")
+
+The `Style Warnings` section appears only when style checks (Section 2.1e) emit at least one
+warning. It is omitted entirely when no style warnings are found. Style warnings are distinct from
+`Diff-Based Warnings` (Section 4): style warnings reflect the quality of an individual ADR's
+content; diff-based warnings reflect patterns in the current git diff.
 
 ---
 
@@ -131,6 +175,10 @@ If no diff-based warnings are found, this section is omitted from the report.
 | Any structural check fails in any directory | **FAIL** |
 | No ADR directories found | **PASS** (warning emitted) |
 | Diff-based warnings present | **PASS** (warnings are informational) |
+| Style warnings present (whole-directory mode) | **PASS** (warnings are informational) |
+| Scoped mode — structural check fails | **FAIL** |
+| Scoped mode — style warning emitted | **PASS** (warning is informational) |
+| Scoped mode — diff-based warnings | Skipped (not evaluated) |
 
 Gate consumers MUST treat a **FAIL** result as a gate-blocking failure. Gate consumers MUST
 treat diff-based warnings as informational only — they must be logged in the progress file and
@@ -140,8 +188,21 @@ presented to the user, but they do not block the gate.
 
 ## 6. Invocation
 
-- **User-invocable:** `/adr-check`
+- **User-invocable (whole-directory mode):** `/adr-check`
+  Validates all ADR directories discovered via Section 1.1. Runs all checks (Sections 2.1–2.3
+  and Section 4).
+
+- **User-invocable (scoped mode):** `/adr-check path/to/NNNN-adr-file.md`
+  Validates only the specified ADR file. Runs structural checks (Section 2.1) and style checks
+  (Section 2.1e) only. Skips index sync (Section 2.2), cross-reference checks (Section 2.3),
+  and diff-based warnings (Section 4).
+
 - **Model-invocable:** The skill description includes phrases matching ADR validation context
   so the model can auto-trigger it when relevant.
-- **Gate invocation:** The gate template calls the skill by name. If the skill is not installed,
-  the gate falls back to basic directory scanning (see FR-011 in the PRD).
+
+- **Lifecycle skill invocation (scoped):** Lifecycle skills (`adr-create`, `adr-supersede`,
+  `adr-deprecate`) invoke the skill in scoped mode against the file they just wrote:
+  `adr-check <path>`. This validates only the newly written ADR without noise from other files.
+
+- **Gate invocation:** The gate template calls the skill by name in whole-directory mode. If the
+  skill is not installed, the gate falls back to basic directory scanning (see FR-011 in the PRD).

--- a/adr-wizard/skills/adr-check/references/adr-check-contract.md
+++ b/adr-wizard/skills/adr-check/references/adr-check-contract.md
@@ -33,18 +33,28 @@ validate.
 
 ### 1.2 Scoped Mode
 
-When the skill is invoked with a file path argument (e.g., `/adr-check docs/adrs/0001-foo.md`),
-it enters **scoped mode**:
+When invoked with an argument, the skill enters **scoped mode**. The argument determines the
+target scope — three sub-modes are supported:
 
-- Only the specified file is validated.
-- Only structural checks (Section 2.1) and style checks (Section 2.1e) run against that file.
-- Section 2.2 (Index Sync) and Section 2.3 (Cross-Reference Integrity) are skipped.
-- Section 4 (Diff-Based Warnings) is skipped entirely.
-- The report scope is limited to the single file rather than a directory.
+- **Scoped (file):** The argument is a path to a single `.md` file
+  (e.g., `/adr-check docs/adrs/0001-foo.md`). Only that file is validated. Runs Section 2.1
+  (structural) and Section 2.1e (style check) only. Sections 2.2, 2.3, and 4 are skipped.
 
-Scoped mode is designed for use by lifecycle skills (`adr-create`, `adr-supersede`,
-`adr-deprecate`) that need to validate only the file they just wrote, without noise from
-unrelated ADRs or diff patterns.
+- **Scoped (directory):** The argument is a path to a directory
+  (e.g., `/adr-check docs/adrs/`). All ADR files in that directory are validated. Runs
+  Sections 2.1, 2.1e, 2.2, and 2.3 for that directory only. Section 4 is skipped.
+
+- **Scoped (query):** The argument is a natural-language description
+  (e.g., `/adr-check "validate only ADRs impacting the Zip Event management components"`).
+  The skill uses model judgment to identify which ADR files across all discovered directories
+  match the query. Runs Section 2.1 and Section 2.1e against each matched file. Sections 2.2,
+  2.3, and 4 are skipped.
+
+All scoped sub-modes skip Section 4 (Diff-Based Warnings). Section 4 is exclusive to Global mode.
+
+Scoped mode is designed for intentional, targeted validation: lifecycle skills use
+`Scoped (file)` for post-write validation; users and tools can use `Scoped (directory)` or
+`Scoped (query)` to narrow a check to a relevant subset without diff-based noise.
 
 ---
 
@@ -105,19 +115,25 @@ For ADRs with a `Supersedes: ADR-NNNN` field:
 
 ## 3. Output — Validation Report
 
-The skill MUST output a structured report in the following format:
+The skill MUST output a structured report. The format is identical regardless of mode; the
+`Mode` and `ADRs` header rows provide context for all rows that follow.
 
 ```
 ADR Check Report
 ================
 
-Directory: <path>
+Mode:    Global | Scoped (file) | Scoped (directory) | Scoped (query)
+Target:  <path, directory path, or natural-language query>
+ADRs:    <comma-separated list of all ADR filenames validated, e.g. "0001-foo.md, 0002-bar.md">
+
+Results
+-------
+<path/to/directory-or-file>:
   Status: PASS | FAIL
   Issues:
     - [ADR-NNNN] <description of issue>
-    - ...
 
-Directory: <path>
+<path/to/next-item>:
   Status: PASS
   Issues: none
 
@@ -125,18 +141,26 @@ Style Warnings (advisory only — not gate-blocking)
 ===================================================
   - [ADR-NNNN] <style warning message>
 
+Diff-Based Warnings (advisory only — not gate-blocking)
+========================================================
+  - [WARNING] <message>
+
 Overall: PASS | FAIL
 ```
+
+**Results grouping:**
+- **Global** and **Scoped (directory):** Group results by directory path.
+- **Scoped (file)** and **Scoped (query):** List each validated file as its own result entry.
+
+**Conditional sections:**
+- `Style Warnings` — appears only when Section 2.1e emits at least one warning; omitted otherwise.
+- `Diff-Based Warnings` — appears only in Global mode when Section 4 emits warnings; omitted in
+  all scoped sub-modes and when no diff warnings are found.
 
 On failure, each issue entry MUST include:
 - Which ADR file is affected (by number and filename)
 - What check failed
 - A specific remediation step (e.g., "Add a non-empty ## Context section to docs/adrs/003-foo.md")
-
-The `Style Warnings` section appears only when style checks (Section 2.1e) emit at least one
-warning. It is omitted entirely when no style warnings are found. Style warnings are distinct from
-`Diff-Based Warnings` (Section 4): style warnings reflect the quality of an individual ADR's
-content; diff-based warnings reflect patterns in the current git diff.
 
 ---
 
@@ -169,16 +193,17 @@ If no diff-based warnings are found, this section is omitted from the report.
 
 ## 5. Pass / Fail Semantics
 
-| Condition | Result |
-|-----------|--------|
-| All structural checks pass for all directories | **PASS** |
-| Any structural check fails in any directory | **FAIL** |
-| No ADR directories found | **PASS** (warning emitted) |
-| Diff-based warnings present | **PASS** (warnings are informational) |
-| Style warnings present (whole-directory mode) | **PASS** (warnings are informational) |
-| Scoped mode — structural check fails | **FAIL** |
-| Scoped mode — style warning emitted | **PASS** (warning is informational) |
-| Scoped mode — diff-based warnings | Skipped (not evaluated) |
+| Mode | Condition | Result |
+|------|-----------|--------|
+| Global | All structural checks pass | **PASS** |
+| Global | Any structural check fails | **FAIL** |
+| Global | No ADR directories found | **PASS** (warning emitted) |
+| Global | Diff-based warnings present | **PASS** (informational only) |
+| Global | Style warnings present | **PASS** (informational only) |
+| Scoped (any) | Structural check fails on target | **FAIL** |
+| Scoped (any) | Style warning emitted | **PASS** (informational only) |
+| Scoped (any) | Diff-based warnings | Skipped — not evaluated |
+| Scoped (query) | No ADRs match the query | **PASS** (advisory warning emitted) |
 
 Gate consumers MUST treat a **FAIL** result as a gate-blocking failure. Gate consumers MUST
 treat diff-based warnings as informational only — they must be logged in the progress file and
@@ -188,21 +213,26 @@ presented to the user, but they do not block the gate.
 
 ## 6. Invocation
 
-- **User-invocable (whole-directory mode):** `/adr-check`
-  Validates all ADR directories discovered via Section 1.1. Runs all checks (Sections 2.1–2.3
-  and Section 4).
+- **Global mode:** `/adr-check`
+  No argument. Validates all ADR directories discovered via Section 1.1. Runs all checks
+  (Sections 2.1–2.3 and Section 4).
 
-- **User-invocable (scoped mode):** `/adr-check path/to/NNNN-adr-file.md`
-  Validates only the specified ADR file. Runs structural checks (Section 2.1) and style checks
-  (Section 2.1e) only. Skips index sync (Section 2.2), cross-reference checks (Section 2.3),
-  and diff-based warnings (Section 4).
+- **Scoped (file):** `/adr-check path/to/NNNN-adr-file.md`
+  Argument is a `.md` file path. Validates only that file. Runs Sections 2.1 and 2.1e; skips
+  2.2, 2.3, and 4.
 
-- **Model-invocable:** The skill description includes phrases matching ADR validation context
-  so the model can auto-trigger it when relevant.
+- **Scoped (directory):** `/adr-check path/to/adrs/`
+  Argument is a directory path. Validates all ADR files in that directory. Runs Sections 2.1,
+  2.1e, 2.2, and 2.3 for that directory only; skips Section 4.
 
-- **Lifecycle skill invocation (scoped):** Lifecycle skills (`adr-create`, `adr-supersede`,
-  `adr-deprecate`) invoke the skill in scoped mode against the file they just wrote:
-  `adr-check <path>`. This validates only the newly written ADR without noise from other files.
+- **Scoped (query):** `/adr-check "natural language description"`
+  Argument is a quoted or unquoted natural-language string that is not a resolvable path. The
+  model identifies matching ADRs and runs Sections 2.1 and 2.1e against them; skips 2.2, 2.3,
+  and 4.
 
-- **Gate invocation:** The gate template calls the skill by name in whole-directory mode. If the
-  skill is not installed, the gate falls back to basic directory scanning (see FR-011 in the PRD).
+- **Lifecycle skill invocation:** Lifecycle skills (`adr-create`, `adr-supersede`,
+  `adr-deprecate`) invoke `Scoped (file)` mode against the file they just wrote. This validates
+  only the newly written ADR without noise from other files or diff patterns.
+
+- **Gate invocation:** The gate template calls the skill in Global mode. If the skill is not
+  installed, the gate falls back to basic directory scanning (see FR-011 in the PRD).

--- a/adr-wizard/skills/adr-create/SKILL.md
+++ b/adr-wizard/skills/adr-create/SKILL.md
@@ -12,6 +12,43 @@ directory's README.md index.
 
 ---
 
+## Step 0 — Evaluate decision worthiness
+
+Before creating an ADR, assess whether the decision genuinely warrants one using the following
+signals and heuristics.
+
+**Qualifying signals** (at least one must apply):
+
+| Signal | Example |
+|--------|---------|
+| Cross-cutting concern — affects multiple modules, services, or teams | Choosing an authentication strategy |
+| Non-obvious to a new contributor — requires context not visible in the code | Why a non-standard folder layout was chosen |
+| Costly to reverse — migration cost is significant if undone | Switching databases or serialisation formats |
+| Multiple alternatives were considered — a deliberate choice was made among options | Evaluating three caching strategies before choosing one |
+
+**Detection heuristics:**
+- "Would a new contributor question this decision?"
+- "Did we discuss multiple approaches before choosing one?"
+- "Does this constrain future decisions or limit flexibility?"
+- "Is this intentionally inconsistent with surrounding code or convention?"
+
+**Explicit skip cases** (do not create an ADR for these):
+- Routine implementation choices (e.g., which loop construct to use)
+- Style preferences already captured by a linter or style guide
+- Decisions entirely local to one function or file with no broader impact
+
+**If no qualifying signal applies:** surface this to the user:
+
+```
+AskUserQuestion:
+  This decision may not meet the threshold for an ADR (no cross-cutting concern, no
+  significant reversal cost, no alternatives considered). Would you like to proceed
+  anyway, or does this need more context?
+```
+
+Wait for the user's response. If the user confirms the decision warrants an ADR, continue to
+Step 1. If the user chooses to abort, stop and explain what would qualify.
+
 ## Step 1 — Discover ADR directories
 
 1. Read the project's `CLAUDE.md`.
@@ -93,6 +130,10 @@ For each section, gather information as follows:
 
 ### Context
 
+**Quality criteria:** Describe the problem and the forces acting on the decision — not the
+solution. Avoid advocating for the chosen approach in this section. The reader should understand
+why a decision was needed, not be pre-sold on the answer.
+
 Write a short paragraph explaining **why** this decision is needed. Draw from:
 - The conversation history (what problem was being discussed?)
 - Recent code changes or files under discussion
@@ -102,6 +143,11 @@ If the conversation does not provide enough context, ask:
 > What problem or situation prompted this decision? What constraints are in play?
 
 ### Decision
+
+**Quality criteria:** Use active voice — "We decided to X" or "We will use Y". Be specific and
+declarative. Avoid passive constructions such as "it was felt that" or "it was agreed". State
+exactly what was chosen, not why (that belongs in Context) or what happens next (that belongs in
+Consequences).
 
 Write a few sentences stating **what** was decided. Be specific and declarative (e.g., "We will
 use PostgreSQL 16 as the primary data store for all user-facing services"). Draw from:
@@ -113,10 +159,15 @@ If the decision is ambiguous (e.g., the user only gave a vague title), ask:
 
 ### Consequences
 
+**Quality criteria:** Must include at least one genuinely adverse consequence or trade-off. An
+ADR that only lists benefits is less credible — every architectural choice involves giving
+something up. Target 200–400 words total for the consequences section. If substantially more is
+needed, consider whether the decision should be split into two ADRs.
+
 Write 3–7 bullet points covering both **positive** and **negative** consequences of this
 decision. Include:
 - Benefits the team expects to gain
-- Trade-offs or risks being accepted
+- Trade-offs or risks being accepted (at least one — required for credibility)
 - Any follow-up work this decision creates
 - Migration or compatibility implications, if applicable
 
@@ -167,3 +218,18 @@ Inform the user:
 > Updated index: `<target_dir>/README.md`
 >
 > Review the ADR and change the Status to `Accepted` when the decision is finalised.
+>
+> Tip: commit this ADR in the same PR as (or just before) the code it describes so the decision
+> and implementation are traceable together.
+
+## Step 9 — Post-write validation
+
+1. Invoke `adr-check` in scoped mode against the newly created ADR file:
+   `adr-check <target_dir>/<NNNN>-<slug>.md`
+2. Review the result:
+   - **Structural FAIL:** Block completion and present the issues to the user. Prompt them to
+     resolve the structural problems before the skill confirms completion. Offer to fix the issues
+     directly if they are straightforward (e.g., a missing section).
+   - **Style warnings:** Display the warnings to the user but do not block. The ADR is considered
+     complete; the user may choose to address the warnings or not.
+   - **PASS (no warnings):** The skill completes successfully with no further action.

--- a/adr-wizard/skills/adr-create/SKILL.md
+++ b/adr-wizard/skills/adr-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adr-create
-description: "Create a new Architecture Decision Record (ADR) in the correct directory with auto-numbering and index updates. Triggers when the user or model discusses an architectural decision, design choice, technical decision, or needs to document a new architectural pattern, technology selection, or system design choice. Invocable via /adr-create <decision summary>."
+description: "This skill should be used when the user asks to 'create an ADR', 'document an architectural decision', 'record a design decision', 'write an architecture decision record', or when the model identifies an architectural decision in context that warrants formal documentation. Evaluates decision worthiness before authoring and guides section drafting."
 argument-hint: "Brief description of the architectural decision (e.g., 'Use PostgreSQL for primary storage')"
 user-invocable: true
 ---
@@ -16,7 +16,7 @@ directory's README.md index.
 
 ### Phase A — Silent evaluation (always runs first)
 
-Using your domain knowledge and the full conversation context, assess the decision across these
+Using domain knowledge and the full conversation context, assess the decision across these
 axes before engaging the user at all:
 
 | Axis | What to assess |
@@ -27,7 +27,7 @@ axes before engaging the user at all:
 | **Tradeoffs** | Does the conversation context already surface what was given up? |
 | **Existing ADRs** | Does this decision extend, contradict, or supersede a prior architectural choice? |
 
-**If Phase A gives you a clear verdict**, act on it directly — no debate needed:
+**If Phase A yields a clear verdict**, act on it directly — no debate needed:
 
 - **Clear yes** (cross-cutting, meaningful alternatives existed, non-trivial reversal cost, or
   intersects an existing ADR): proceed to Step 1 without engaging the user.
@@ -42,9 +42,9 @@ context, or the decision boundaries are unclear — proceed to Phase B.
 
 ### Phase B — Adversarial debate (only when Phase A is inconclusive)
 
-Engage the user to extract the information Phase A could not resolve. The debate loads your
-context with the substance Steps 4–5 will need; it also surfaces the decision's true shape,
-which may not match the user's original framing.
+Engage the user to extract the information Phase A could not resolve. The debate loads the
+agent's context with the substance Steps 4–5 will need; it also surfaces the decision's true
+shape, which may not match the user's original framing.
 
 **Your posture is adversarial-constructive.** Argue against the ADR's necessity — or against the
 framing — until the picture is clear. State challenges directly; do not soften them into
@@ -148,7 +148,7 @@ characters replaced with hyphens.
 
 The skill is responsible for authoring every section of the ADR — do not leave template
 placeholders for the user. Infer content from the conversation context, codebase state, and
-`decision_summary`. When you lack enough information to write a section confidently, use
+`decision_summary`. When information is insufficient to write a section confidently, use
 `AskUserQuestion` to interview the user before proceeding.
 
 For each section, gather information as follows:
@@ -196,12 +196,12 @@ decision. Include:
 - Any follow-up work this decision creates
 - Migration or compatibility implications, if applicable
 
-If you cannot infer consequences from context, ask:
+If consequences cannot be inferred from context, ask:
 > What are the main benefits and trade-offs of this decision? Any follow-up work it creates?
 
 ### Interview flow
 
-Batch your questions — if you need clarity on multiple sections, ask them together in a single
+Batch questions — if clarity is needed on multiple sections, ask them together in a single
 `AskUserQuestion` call rather than one at a time. Proceed to file creation only after all
 sections have substantive content.
 

--- a/adr-wizard/skills/adr-create/SKILL.md
+++ b/adr-wizard/skills/adr-create/SKILL.md
@@ -12,23 +12,45 @@ directory's README.md index.
 
 ---
 
-## Step 0 — Debate ADR necessity
+## Step 0 — Evaluate decision worthiness
 
-Before opening an ADR template, engage the user in a structured debate to establish that the
-decision warrants a permanent record. The debate serves two purposes: (1) filter decisions that
-do not meet the bar, and (2) surface the nuances of the decision in conversation — the richer
-this exchange, the better the ADR that follows, because the debate loads the agent's context with
-the substance that Steps 4–5 will draw on.
+### Phase A — Silent evaluation (always runs first)
 
-**Your posture is adversarial-constructive.** Argue *against* the ADR's necessity until the user
-has made a convincing case. Take explicit counterpoints. Do not be a passive facilitator — this
-is the first act of co-authorship, not a form to fill in.
+Using your domain knowledge and the full conversation context, assess the decision across these
+axes before engaging the user at all:
 
-### Opening the debate
+| Axis | What to assess |
+|------|---------------|
+| **Alternatives** | Do obvious alternatives exist in this domain? Would a knowledgeable engineer have weighed options, or was this effectively forced? |
+| **Scope** | Does the decision cross module, team, or service boundaries — or is it local to one function or file? |
+| **Reversibility** | Is the cost of undoing this significant (data migration, API contract change, team retraining)? |
+| **Tradeoffs** | Does the conversation context already surface what was given up? |
+| **Existing ADRs** | Does this decision extend, contradict, or supersede a prior architectural choice? |
 
-Read the user's decision summary (from the argument or conversation context). Identify which of
-the axes below are weakest, then raise 1–3 targeted challenges. You do not need to challenge all
-axes — press the ones where the case is thinnest.
+**If Phase A gives you a clear verdict**, act on it directly — no debate needed:
+
+- **Clear yes** (cross-cutting, meaningful alternatives existed, non-trivial reversal cost, or
+  intersects an existing ADR): proceed to Step 1 without engaging the user.
+- **Clear no** (routine implementation detail, derivable from code, no alternatives were
+  ever in play, entirely local): inform the user plainly, suggest a lighter alternative (inline
+  comment, team discussion note), and stop. No escape hatch — the assessment is confident.
+
+**If Phase A is inconclusive** — alternatives are ambiguous, tradeoffs are not surfaced in
+context, or the decision boundaries are unclear — proceed to Phase B.
+
+---
+
+### Phase B — Adversarial debate (only when Phase A is inconclusive)
+
+Engage the user to extract the information Phase A could not resolve. The debate loads your
+context with the substance Steps 4–5 will need; it also surfaces the decision's true shape,
+which may not match the user's original framing.
+
+**Your posture is adversarial-constructive.** Argue against the ADR's necessity — or against the
+framing — until the picture is clear. State challenges directly; do not soften them into
+questions with obvious answers.
+
+**Challenge axes** (raise 1–3 based on what Phase A left unresolved):
 
 | Axis | Counterpoint to raise |
 |------|-----------------------|
@@ -36,32 +58,21 @@ axes — press the ones where the case is thinnest.
 | **Obviousness** | "An experienced engineer reading the code would likely infer this from [Y]. What would they miss that the ADR adds?" |
 | **Reversibility** | "What is the real cost of undoing this? If it is low, a permanent record may not be warranted." |
 | **Alternatives** | "What alternatives did you actually consider? If only one option was ever on the table, this may be recording an outcome rather than a decision." |
-| **Novelty** | "Is this consistent with an existing ADR? If so, it may be an implementation of an already-approved pattern rather than a new architectural decision." |
+| **Novelty** | "Is this consistent with an existing ADR? If so, it may be implementing an already-approved pattern rather than making a new decision." |
 
-### Conducting the debate
+Conduct 1–2 exchanges. Steelman the user's responses, then counter if the case is still
+unconvincing. The debate ends when the picture is clear enough to route to an outcome.
 
-1. Raise your challenges. State them directly — do not soften them into questions with obvious
-   answers.
-2. Let the user respond. Steelman their position, then counter again if the case is still not
-   convincing.
-3. **If the user makes a convincing case** — they name real alternatives, demonstrate genuine
-   cross-cutting impact, or show that a new contributor would be materially misled without this
-   record — accept it without ceremony and proceed to Step 1. Do not offer the escape hatch.
-4. **Only if the user cannot substantiate their case** after one or two exchanges — they cannot
-   name alternatives, the impact is clearly local, or the decision is already derivable from
-   existing ADRs — surface the escape hatch:
+---
 
-   > "I'm not convinced this clears the bar for a permanent ADR. It may be better suited as an
-   > inline comment or a team discussion note. That said, you're the author — would you like to
-   > proceed anyway, or revisit the decision framing?"
+### Outcome routing (after Phase A or Phase B)
 
-   Use `AskUserQuestion` with options: **Proceed anyway** and **Revisit framing**. If the user
-   chooses to proceed, continue to Step 1. If they choose to revisit, restart the debate from
-   the top with their updated framing.
-
-**Do not offer the escape hatch as an opening move or after a single challenge.** It is a last
-resort, reached only when the debate has run its course and the user's case has not landed. The
-debate is the feature.
+| Outcome | Action |
+|---------|--------|
+| **Single ADR warranted** | Proceed to Step 1. |
+| **Multiple ADRs warranted** | The decision is compound. Surface each distinct decision to the user: "This looks like two separate decisions: [A] and [B]. I'll create them in sequence — starting with [A]." Proceed to Step 1 for the first; loop back to Step 0 for each subsequent. |
+| **Supersede or deprecate warranted** | The decision changes a prior architectural choice. Surface this: "This appears to supersede ADR-NNNN ([title]). I'll hand off to `/adr-supersede`." Stop and invoke the appropriate lifecycle skill. |
+| **Decision does not warrant an ADR** (Phase A clear no, or debate concludes no) | Explain why confidently. If Phase A was the source (clear no), stop without offering an escape hatch. If the debate concludes no, offer the escape hatch: "I'm not convinced this clears the bar for a permanent ADR. That said, you're the author — proceed anyway, or revisit the framing?" Use `AskUserQuestion` with **Proceed anyway** and **Revisit framing**. Revisit restarts Phase B with the updated framing; proceed continues to Step 1. |
 
 ## Step 1 — Discover ADR directories
 

--- a/adr-wizard/skills/adr-create/SKILL.md
+++ b/adr-wizard/skills/adr-create/SKILL.md
@@ -12,42 +12,56 @@ directory's README.md index.
 
 ---
 
-## Step 0 — Evaluate decision worthiness
+## Step 0 — Debate ADR necessity
 
-Before creating an ADR, assess whether the decision genuinely warrants one using the following
-signals and heuristics.
+Before opening an ADR template, engage the user in a structured debate to establish that the
+decision warrants a permanent record. The debate serves two purposes: (1) filter decisions that
+do not meet the bar, and (2) surface the nuances of the decision in conversation — the richer
+this exchange, the better the ADR that follows, because the debate loads the agent's context with
+the substance that Steps 4–5 will draw on.
 
-**Qualifying signals** (at least one must apply):
+**Your posture is adversarial-constructive.** Argue *against* the ADR's necessity until the user
+has made a convincing case. Take explicit counterpoints. Do not be a passive facilitator — this
+is the first act of co-authorship, not a form to fill in.
 
-| Signal | Example |
-|--------|---------|
-| Cross-cutting concern — affects multiple modules, services, or teams | Choosing an authentication strategy |
-| Non-obvious to a new contributor — requires context not visible in the code | Why a non-standard folder layout was chosen |
-| Costly to reverse — migration cost is significant if undone | Switching databases or serialisation formats |
-| Multiple alternatives were considered — a deliberate choice was made among options | Evaluating three caching strategies before choosing one |
+### Opening the debate
 
-**Detection heuristics:**
-- "Would a new contributor question this decision?"
-- "Did we discuss multiple approaches before choosing one?"
-- "Does this constrain future decisions or limit flexibility?"
-- "Is this intentionally inconsistent with surrounding code or convention?"
+Read the user's decision summary (from the argument or conversation context). Identify which of
+the axes below are weakest, then raise 1–3 targeted challenges. You do not need to challenge all
+axes — press the ones where the case is thinnest.
 
-**Explicit skip cases** (do not create an ADR for these):
-- Routine implementation choices (e.g., which loop construct to use)
-- Style preferences already captured by a linter or style guide
-- Decisions entirely local to one function or file with no broader impact
+| Axis | Counterpoint to raise |
+|------|-----------------------|
+| **Scope** | "This sounds contained to [X]. Why does someone working on a different part of the system six months from now need to know about it?" |
+| **Obviousness** | "An experienced engineer reading the code would likely infer this from [Y]. What would they miss that the ADR adds?" |
+| **Reversibility** | "What is the real cost of undoing this? If it is low, a permanent record may not be warranted." |
+| **Alternatives** | "What alternatives did you actually consider? If only one option was ever on the table, this may be recording an outcome rather than a decision." |
+| **Novelty** | "Is this consistent with an existing ADR? If so, it may be an implementation of an already-approved pattern rather than a new architectural decision." |
 
-**If no qualifying signal applies:** surface this to the user:
+### Conducting the debate
 
-```
-AskUserQuestion:
-  This decision may not meet the threshold for an ADR (no cross-cutting concern, no
-  significant reversal cost, no alternatives considered). Would you like to proceed
-  anyway, or does this need more context?
-```
+1. Raise your challenges. State them directly — do not soften them into questions with obvious
+   answers.
+2. Let the user respond. Steelman their position, then counter again if the case is still not
+   convincing.
+3. **If the user makes a convincing case** — they name real alternatives, demonstrate genuine
+   cross-cutting impact, or show that a new contributor would be materially misled without this
+   record — accept it without ceremony and proceed to Step 1. Do not offer the escape hatch.
+4. **Only if the user cannot substantiate their case** after one or two exchanges — they cannot
+   name alternatives, the impact is clearly local, or the decision is already derivable from
+   existing ADRs — surface the escape hatch:
 
-Wait for the user's response. If the user confirms the decision warrants an ADR, continue to
-Step 1. If the user chooses to abort, stop and explain what would qualify.
+   > "I'm not convinced this clears the bar for a permanent ADR. It may be better suited as an
+   > inline comment or a team discussion note. That said, you're the author — would you like to
+   > proceed anyway, or revisit the decision framing?"
+
+   Use `AskUserQuestion` with options: **Proceed anyway** and **Revisit framing**. If the user
+   chooses to proceed, continue to Step 1. If they choose to revisit, restart the debate from
+   the top with their updated framing.
+
+**Do not offer the escape hatch as an opening move or after a single challenge.** It is a last
+resort, reached only when the debate has run its course and the user's case has not landed. The
+debate is the feature.
 
 ## Step 1 — Discover ADR directories
 

--- a/adr-wizard/skills/adr-deprecate/SKILL.md
+++ b/adr-wizard/skills/adr-deprecate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adr-deprecate
-description: "Deprecate an existing Architecture Decision Record (ADR) that is no longer relevant, recording the reason while preserving history. Use when an architectural decision, design choice, or technical decision is obsolete or no longer applicable. Invocable via /adr-deprecate <ADR number> <reason for deprecation>."
+description: "This skill should be used when the user asks to 'deprecate an ADR', 'mark an ADR as obsolete', 'retire an architectural decision', 'flag an ADR as no longer applicable', or when an existing architectural decision is no longer relevant and should be marked as deprecated while preserving history."
 argument-hint: "ADR number to deprecate and why (e.g., '5 No longer applicable after migration to microservices')"
 user-invocable: true
 ---

--- a/adr-wizard/skills/adr-deprecate/SKILL.md
+++ b/adr-wizard/skills/adr-deprecate/SKILL.md
@@ -10,6 +10,10 @@ user-invocable: true
 Marks an existing ADR as deprecated, records the reason in the file, and updates the directory's
 README.md index.
 
+> ADRs are **additive only**: never delete or heavily rewrite an accepted ADR. This skill exists
+> so that the history of decisions is preserved — the old ADR remains readable, and the new ADR
+> explains what changed and why.
+
 ---
 
 ## Step 1 — Discover ADR directories
@@ -100,3 +104,20 @@ Inform the user:
 > Reason: <deprecation_reason>
 > Updated: `<target_dir>/<NNNN>-<slug>.md`
 > Updated index: `<target_dir>/README.md`
+
+## Step 8 — Post-write validation
+
+Invoke `adr-check` in scoped mode against the deprecated ADR file:
+
+```
+/adr-check <deprecated_adr_path>
+```
+
+Display all output to the user.
+
+- If `adr-check` returns a structural **FAIL**: block completion and prompt the user to resolve
+  the issue before proceeding:
+  > The deprecated ADR has a structural validation failure. Please fix the issue above before
+  > confirming this deprecation is complete.
+- If `adr-check` emits style warnings only: display them and continue. Style warnings are
+  informational and do not block completion.

--- a/adr-wizard/skills/adr-supersede/SKILL.md
+++ b/adr-wizard/skills/adr-supersede/SKILL.md
@@ -10,6 +10,10 @@ user-invocable: true
 Creates a new ADR that supersedes an existing one, updates the old ADR's status, and maintains
 bidirectional cross-references in both files and the directory index.
 
+> ADRs are **additive only**: never delete or heavily rewrite an accepted ADR. This skill exists
+> so that the history of decisions is preserved — the old ADR remains readable, and the new ADR
+> explains what changed and why.
+
 ---
 
 ## Step 1 — Discover ADR directories
@@ -162,3 +166,24 @@ Inform the user:
 > Updated index: `<target_dir>/README.md`
 >
 > Review the new ADR and change the Status to `Accepted` when finalised.
+
+## Step 10 — Post-write validation
+
+Invoke `adr-check` in scoped mode against the superseded ADR (the file this skill directly
+modified in Step 7):
+
+```
+/adr-check <old_adr_path>
+```
+
+Display all output to the user.
+
+- If `adr-check` returns a structural **FAIL**: block completion and prompt the user to resolve
+  the issue before proceeding:
+  > The superseded ADR has a structural validation failure. Please fix the issue above before
+  > confirming this supersession is complete.
+- If `adr-check` emits style warnings only: display them and continue. Style warnings are
+  informational and do not block completion.
+
+Note: the new ADR (created via `adr-create` in Step 6) is already validated by `adr-create`'s
+own post-write step — do not run `adr-check` on it again here.

--- a/adr-wizard/skills/adr-supersede/SKILL.md
+++ b/adr-wizard/skills/adr-supersede/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adr-supersede
-description: "Supersede an existing Architecture Decision Record (ADR) with a new one, preserving history with bidirectional cross-references. Use when an architectural decision, design choice, or technical decision has changed and the old ADR needs to be replaced. Invocable via /adr-supersede <old ADR#>[->new ADR#] <new decision and reason>."
+description: "This skill should be used when the user asks to 'supersede an ADR', 'replace an architectural decision', 'update an ADR with a new decision', 'mark an ADR as superseded', or when an existing architectural decision has changed and needs to be replaced while preserving the historical record."
 argument-hint: "Old ADR number, optional arrow to existing new ADR number, and the new decision or reason (e.g., '3 Switching from PostgreSQL to CockroachDB for horizontal scaling' or '3->7 CockroachDB chosen to replace PostgreSQL')"
 user-invocable: true
 ---
@@ -83,7 +83,7 @@ From these sources, derive:
 - `new_decision`: what the new decision is, stated specifically and declaratively.
 
 If any of these cannot be confidently inferred, interview the user with `AskUserQuestion`.
-Batch questions together — for example, if you need both the new title and the rationale:
+Batch questions together — for example, if both the new title and rationale are needed:
 
 > I'm superseding ADR-NNNN (<old_title>). To write the replacement ADR, I need:
 >
@@ -118,9 +118,9 @@ Write 3–7 bullet points covering:
 - Any follow-up work required (e.g., "migrate existing data", "update deployment configs")
 - What becomes easier vs. harder compared to the superseded approach
 
-If you cannot infer consequences confidently, ask:
-> What are the key benefits of the new approach, and what migration or transition costs do you
-> anticipate?
+If consequences cannot be inferred confidently, ask:
+> What are the key benefits of the new approach, and what migration or transition costs are
+> anticipated?
 
 ## Step 6 — Create the new ADR via adr-create
 


### PR DESCRIPTION
## Goals

- Add decision-worthiness evaluation to \`adr-create\` (Step 0) that surfaces low-signal decisions and allows confirm/abort
- Add per-section writing quality criteria to \`adr-create\` Step 5 (Context, Decision, Consequences guidance)
- Add advisory style check (Check 2.1e) to \`adr-check\` that warns when Consequences section has no genuinely adverse outcome
- Add scoped validation mode to \`adr-check\` — three sub-modes: Scoped (file), Scoped (directory), Scoped (query via natural language)
- Unify \`adr-check\` report format: consistent \`Mode / Target / ADRs\` header across all modes; diff-based warnings explicitly Global-only
- Add post-write scoped \`adr-check\` invocation to all lifecycle skills (\`adr-create\` Step 9, \`adr-supersede\` Step 10, \`adr-deprecate\` Step 8)
- Add additive-only principle note to \`adr-supersede\` and \`adr-deprecate\`
- Add PR co-location reminder to \`adr-create\` Step 8

## Stories

- \`FEAT-adr-wizard-authoring-validation-gaps-01\` — Update \`adr-check-contract.md\` to document scoped mode and style-check category
- \`FEAT-adr-wizard-authoring-validation-gaps-02\` — Implement scoped mode and style check in \`adr-check\` SKILL.md
- \`FEAT-adr-wizard-authoring-validation-gaps-03\` — Implement authoring guidance and post-write validation in \`adr-create\` SKILL.md
- \`FEAT-adr-wizard-authoring-validation-gaps-04\` — Add additive-only principle and post-write validation to \`adr-supersede\` and \`adr-deprecate\`
- \`FEAT-adr-wizard-authoring-validation-gaps-05\` — Bump version to \`1.1.0\` and update CHANGELOG

## Post-review changes

- Expanded \`adr-check\` scoped mode from single-file only to three sub-modes: **Scoped (file)**, **Scoped (directory)**, and **Scoped (query)** — natural-language arguments let the model identify matching ADRs without requiring exact paths
- Unified report format: \`Mode / Target / ADRs\` header is now always present regardless of mode; all result rows follow the same structure; \`Diff-Based Warnings\` section explicitly scoped to Global mode only
- \`argument-hint\` and \`description\` front-matter updated to reflect expanded invocation options
- Follow-on issue filed for the \`adr-check\` → structural linter + \`adr-reviewer\` architectural consultant split: #18
- Redesigned \`adr-create\` Step 0 into two phases: **Phase A** (silent evaluation against five axes — always runs) + **Phase B** (adversarial debate with user — only when Phase A is inconclusive); outcome routing covers single ADR, compound decisions, supersede/deprecate handoff, and no-ADR conclusions
- Aligned all four modified skill files to \`plugin-dev\` skill-development standard: third-person trigger-phrase descriptions, imperative agent-instruction prose (second-person removed), and formal \`## Additional Resources\` section in \`adr-check\`

Closes #16

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)