### PR TITLE
Fix: prd→session-spec Regressions + session-spec Gates Bundle

### DIFF
--- a/hyperloop/.claude-plugin/plugin.json
+++ b/hyperloop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperloop",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "AI-augmented development for engineers who stay in the loop. Interviews you to build a session-spec (with requirement analysis and conflict resolution), then runs an autonomous specialist agent team with back-pressure gates to implement it — while you review, guide, and approve at every milestone.",
   "author": {
     "name": "Sam Romano",

--- a/hyperloop/CHANGELOG.md
+++ b/hyperloop/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the hyperloop plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-05-08
+
+### Fixed
+
+- Confirmed all three required `TaskUpdate` call sites present in `hyperteam-worker.md`:
+  `in_progress` on claim, `completed` on finish, `pending` rollback on commit failure or
+  unresolvable blocker. "Always update BOTH native task and team-state.json" invariant present
+  in Rules. (Issue #28 item 1)
+- Restored `## Open Questions` resolution gate to `session-spec` Step 6 (Final Conflict Sweep)
+  and Before Saving checklist. Gate was present in the original `prd` skill and was lost during
+  the v2.0.0 rename. (Issue #28 item 2)
+- Removed stale `prd` references from `hyperteam/SKILL.md` frontmatter description and
+  `team-state-schema.md`; updated "On scaffold missing" handler in `hyperteam-lead.md` from
+  "builder" to "worker" to match v3.0.0 self-claim terminology. (Issue #28 item 3)
+
+### Added
+
+- Pre-generation idea-refinement checkpoint (Step 4) in `session-spec` skill. After the
+  interview, skill now summarizes gathered goals/scope/resolved conflicts and asks the user to
+  Proceed or Refine. Capped at 2 refinement iterations — proceeds regardless on the third pass.
+  Added corresponding item to Before Saving checklist. (Issue #22)
+- Two-condition gate for `hyperwork-api-scaffold` as a standalone step in session-spec skill
+  assignment. Standalone step assigned only when BOTH: (a) no existing structure — target
+  modules/files absent and shape indeterminate from existing code; (b) parallelism unlock —
+  scaffolded stubs allow ≥2 workers to proceed independently. Gate not met → structure
+  definition bundled into the first FEAT task that requires it. (Issue #26)
+
 ## [3.0.0] - 2026-05-08
 
 ### Added

--- a/hyperloop/agents/hyperteam-lead.md
+++ b/hyperloop/agents/hyperteam-lead.md
@@ -151,16 +151,16 @@ re-seed the native task list:
 5. If ALL tasks are `validated`, `completed`, or `blocked` and no GATE has run: go to
    **Detect GATE Ready**.
 
-### On scaffold missing (`SendMessage` from builder)
+### On scaffold missing (`SendMessage` from worker)
 
-A builder reported that the scaffold for a task is missing:
+A worker reported that the scaffold for a task is missing:
 
-1. Re-read `team_state_path` to check whether the scaffolder task is `completed` or `validated`.
-2. If the scaffolder task is done but the scaffold file is absent: use `AskUserQuestion` to
+1. Re-read `team_state_path` to check whether the scaffold task is `completed` or `validated`.
+2. If the scaffold task is done but the scaffold file is absent: use `AskUserQuestion` to
    surface the discrepancy.
-3. If the scaffolder task is still `pending` or `in_progress`: broadcast to the team:
+3. If the scaffold task is still `pending` or `in_progress`: broadcast to the team:
 
-   > Scaffold task still in progress. Builder for `<task_id>`: please wait — the scaffolder
+   > Scaffold task still in progress. Worker for `<task_id>`: please wait — the scaffold task
    > will signal when done.
 
 ---

--- a/hyperloop/skills/hyperteam/SKILL.md
+++ b/hyperloop/skills/hyperteam/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hyperteam
-description: "Reads a session-spec, derives a task DAG, gets user approval, writes team-state.json, seeds the native task list, creates a specialist team, and monitors until the back-pressure gate passes. Replaces the legacy /prd + /hyperworker two-step workflow."
+description: "Reads a session-spec, derives a task DAG, gets user approval, writes team-state.json, seeds the native task list, creates a specialist team, and monitors until the back-pressure gate passes."
 user-invocable: true
 disable-model-invocation: true
 ---

--- a/hyperloop/skills/hyperteam/references/team-state-schema.md
+++ b/hyperloop/skills/hyperteam/references/team-state-schema.md
@@ -44,7 +44,7 @@
 
 ## `tasks`
 
-Array of task objects. Each represents one unit of work from PRD DAG or gate remediation.
+Array of task objects. Each represents one unit of work from session-spec DAG or gate remediation.
 
 | Field            | Type                    | Default | Description                                                                                                                                                                                                                              |
 | ---------------- | ----------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/hyperloop/skills/session-spec/SKILL.md
+++ b/hyperloop/skills/session-spec/SKILL.md
@@ -100,8 +100,11 @@ Max 2–3 `AskUserQuestion` calls total. Rules:
    - Python code involved → add `hyperwork-python`
    - TypeScript code involved → add `hyperwork-typescript`
    - Step implements logic against existing contracts (not pure scaffolding) → add `hyperwork-tdd`
-   - Step generates stubs, schemas, or API surface → add `hyperwork-api-scaffold`
    - Step is docs, README, changelog, ADR, or user-facing writing → add `hyperwork-tech-writing`
+   - `hyperwork-api-scaffold` as a **standalone** step only when BOTH hold:
+     (a) **No existing structure** — target modules/files absent and shape indeterminate from existing code.
+     (b) **Parallelism unlock** — scaffolded stubs allow ≥2 workers to proceed independently in next wave; if work remains serial after scaffolding, skip standalone step.
+     **Gate not met** → bundle structure-definition into first FEAT task requiring it: add `hyperwork-api-scaffold` to that task's `skills:` array + note in description that worker creates structure inline before proceeding.
 
    No matches → `skills: none` (explicit sentinel; worker skips loading).
 

--- a/hyperloop/skills/session-spec/SKILL.md
+++ b/hyperloop/skills/session-spec/SKILL.md
@@ -133,6 +133,8 @@ Max 2–3 `AskUserQuestion` calls total. Rules:
 
 Verify: no step contradicts another; no step conflicts with codebase findings from Step 2. Conflict found → raise with user via `AskUserQuestion` and resolve before saving.
 
+**Open-questions gate:** Every item in `## Open Questions` must be: answered inline, explicitly deferred (note rationale in item), or removed. Any unresolved item remaining → raise via `AskUserQuestion` and resolve before saving.
+
 > **Do NOT start implementing. Create spec only.**
 
 ______________________________________________________________________
@@ -150,3 +152,4 @@ ______________________________________________________________________
 - [ ] Each step has `> skills:` annotation (`skills: none` if no rules match)
 - [ ] Old `plans/<branch>-session-spec.md` archived to `plans/archive/` if existed
 - [ ] Final conflict sweep complete — no intra-spec contradictions, no codebase conflicts
+- [ ] All `## Open Questions` items answered, deferred with rationale, or removed

--- a/hyperloop/skills/session-spec/SKILL.md
+++ b/hyperloop/skills/session-spec/SKILL.md
@@ -80,12 +80,11 @@ Max 2–3 `AskUserQuestion` calls total. Rules:
 1. Summarize in 1–3 sentences: goals gathered, scope boundaries, conflicts resolved in Steps 2–3.
 2. `AskUserQuestion`: "Proceed to generate spec, or refine further?"
    - **Proceed** → continue to Step 5.
-   - **Refine** → return to Step 3 for one additional targeted interview round. Cap: max 2 refinement iterations total — if Refine selected twice, proceed to Step 5 regardless on next pass.
+   - **Refine** → return to Step 3 for one additional targeted interview round (budget: 1–2 questions, separate from initial Step 3 budget). Cap: max 2 refinement iterations total — if Refine selected twice, proceed to Step 5 regardless on next pass.
 
 ### Step 5 — Generate Spec
 
-1. If `plans/<branch>-session-spec.md` exists → move to `plans/archive/<branch>-session-spec.md` before writing.
-2. Write `plans/<branch>-session-spec.md` in step→verify format per `references/example-session-spec.md`.
+1. Draft spec content in step→verify format per `references/example-session-spec.md` — do not write to disk yet; Step 6 sweep runs first.
 3. Spec structure:
    - `<source_issues>` non-null → write metadata table **immediately after H1 and before `## Goal`**, one `| Source Issue |` row per issue.
    - `<source_issues>` null → omit table. H1 followed directly by `## Goal`.
@@ -144,6 +143,8 @@ Max 2–3 `AskUserQuestion` calls total. Rules:
 Verify: no step contradicts another; no step conflicts with codebase findings from Step 2. Conflict found → raise with user via `AskUserQuestion` and resolve before saving.
 
 **Open-questions gate:** Every item in `## Open Questions` must be: answered inline, explicitly deferred (note rationale in item), or removed. Any unresolved item remaining → raise via `AskUserQuestion` and resolve before saving.
+
+All sweep checks pass → (1) if `plans/<branch>-session-spec.md` exists, move to `plans/archive/<branch>-session-spec.md`; (2) write drafted spec to disk.
 
 > **Do NOT start implementing. Create spec only.**
 

--- a/hyperloop/skills/session-spec/SKILL.md
+++ b/hyperloop/skills/session-spec/SKILL.md
@@ -75,7 +75,14 @@ Max 2–3 `AskUserQuestion` calls total. Rules:
 
 **Text description mode:** ask 2–3 questions on problem/goal, scope/boundaries, success criteria.
 
-### Step 4 — Generate Spec
+### Step 4 — Pre-Generation Checkpoint
+
+1. Summarize in 1–3 sentences: goals gathered, scope boundaries, conflicts resolved in Steps 2–3.
+2. `AskUserQuestion`: "Proceed to generate spec, or refine further?"
+   - **Proceed** → continue to Step 5.
+   - **Refine** → return to Step 3 for one additional targeted interview round. Cap: max 2 refinement iterations total — if Refine selected twice, proceed to Step 5 regardless on next pass.
+
+### Step 5 — Generate Spec
 
 1. If `plans/<branch>-session-spec.md` exists → move to `plans/archive/<branch>-session-spec.md` before writing.
 2. Write `plans/<branch>-session-spec.md` in step→verify format per `references/example-session-spec.md`.
@@ -129,7 +136,7 @@ Max 2–3 `AskUserQuestion` calls total. Rules:
 
    > **Reading note for agents:** Metadata table (if present) appears **immediately after H1** and **before first `##` section**. Parsers: locate H1, scan forward collecting all `| Source Issue |` rows before `##`; none found → `source_issues` is `null`.
 
-### Step 5 — Final Conflict Sweep
+### Step 6 — Final Conflict Sweep
 
 Verify: no step contradicts another; no step conflicts with codebase findings from Step 2. Conflict found → raise with user via `AskUserQuestion` and resolve before saving.
 
@@ -146,6 +153,7 @@ ______________________________________________________________________
 - [ ] Input mode detected: seedling or text description
 - [ ] `CLAUDE.md` ADR locations, ADR dirs, project source dirs searched for conflicts (Step 2)
 - [ ] Interview complete: ≤3 `AskUserQuestion` calls; ≥1 addressed Step 2 conflicts (if any)
+- [ ] Pre-generation checkpoint (Step 4) presented; user selected Proceed, or refinement cap (2 iterations) reached
 - [ ] `<source_issues>` non-null → metadata table present immediately after H1 and before `## Goal`; null → no table
 - [ ] Spec uses `## Goal / ## Context / ## Non-goals / ## Steps / ## Open Questions` structure
 - [ ] Each step has `**Acceptance Criteria:**` checklist with ≥1 concrete, independently falsifiable `- [ ]` item


### PR DESCRIPTION
## Goal

Bundle fix for three open issues: regression cleanup from the prd→session-spec rename (#28), idea-refinement gate added to session-spec skill (#26), and scaffolding guidance tightened to gate on parallelism value (#22). Result: hyperloop 3.1.0.

## Tasks

- FEAT-regression-and-gates-01 — Audit and confirm TaskUpdate compliance in hyperteam-worker.md
- FEAT-regression-and-gates-02 — Add open-questions resolution gate to session-spec skill
- FEAT-regression-and-gates-03 — Fix stale prd references in frontmatter and body copy
- FEAT-regression-and-gates-04 — Add idea-refinement gate to session-spec skill
- FEAT-regression-and-gates-05 — Add scaffolding gate criteria to session-spec and update guidance
- FEAT-regression-and-gates-06 — Bump version to 3.1.0 and update CHANGELOG

Closes #28
Closes #26
Closes #22

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)