### PR TITLE
chore(hyperloop): bump to 3.1.1 — missed version bump from feat-reduce-sync-scope

### DIFF
--- a/hyperloop/.claude-plugin/plugin.json
+++ b/hyperloop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperloop",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "AI-augmented development for engineers who stay in the loop. Interviews you to build a session-spec (with requirement analysis and conflict resolution), then runs an autonomous specialist agent team with back-pressure gates to implement it — while you review, guide, and approve at every milestone.",
   "author": {
     "name": "Sam Romano",

--- a/hyperloop/CHANGELOG.md
+++ b/hyperloop/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - ADR-004: documents the revert-uncommitted-on-resume decision and its rationale.
+- `session-spec` skill detects `CHANGELOG.md` + version manifest at plan time and auto-appends
+  a version bump + CHANGELOG step (blocked by all preceding FEAT steps, skill: `hyperwork-tech-writing`).
+  Prevents version bump omissions at the source — the spec — rather than relying on GATE enforcement.
 
 ## [3.1.0] - 2026-05-08
 

--- a/hyperloop/CHANGELOG.md
+++ b/hyperloop/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the hyperloop plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2026-05-25
+
+### Changed
+
+- `team-state.json` no longer holds `in_progress` status or `native_task_id` field. Live
+  execution state (`pending` → `in_progress`) is owned exclusively by the native task list
+  (via `TaskUpdate`); JSON is updated only on terminal transitions (`completed`, `failed`,
+  `blocked`, `validated`). Eliminates the JSON/native-task sync hazard on mid-task crashes.
+- Resume flow (Phase 1) now stashes uncommitted/unstaged changes before reconciling state.
+  Orphaned native tasks from the prior session are cancelled via `TaskStop` before re-seeding,
+  preventing duplicate task claims.
+- `split ownership` table added to `team-state-schema.md` documenting which system owns each
+  state category and why.
+
+### Added
+
+- ADR-004: documents the revert-uncommitted-on-resume decision and its rationale.
+
 ## [3.1.0] - 2026-05-08
 
 ### Fixed

--- a/hyperloop/skills/session-spec/SKILL.md
+++ b/hyperloop/skills/session-spec/SKILL.md
@@ -63,7 +63,7 @@ ______________________________________________________________________
 
 Read `CLAUDE.md` for ADR locations. Scan ADR dirs and relevant source dirs for existing code related to requested feature. Identify contradictions between requested and existing. **Mandatory in both modes.**
 
-**Versioning detection (same pass):** Check for `CHANGELOG.md` + version manifest (`plugin.json`, `package.json`, `pyproject.toml`, `Cargo.toml`, etc.) in the repo. If both present → set `<has_versioning>: true`. Read `CLAUDE.md` for bump-type rules (major/minor/patch criteria). Determine `<bump_type>` from those rules + nature of changes being spec'd.
+**Versioning detection (same pass):** Check for `CHANGELOG.md` + version manifest (`plugin.json`, `package.json`, `pyproject.toml`, `Cargo.toml`, etc.) in the repo. If both present → read `CLAUDE.md` for bump-type rules (major/minor/patch criteria) and determine `<bump_type>` from those rules + nature of changes being spec'd.
 
 ### Step 3 — Single Focused Interview
 
@@ -140,7 +140,7 @@ Max 2–3 `AskUserQuestion` calls total. Rules:
 
    > **Reading note for agents:** Metadata table (if present) appears **immediately after H1** and **before first `##` section**. Parsers: locate H1, scan forward collecting all `| Source Issue |` rows before `##`; none found → `source_issues` is `null`.
 
-5. **Version bump step (conditional).** `<has_versioning>` true → append final step after all FEAT/DOC steps:
+5. **Version bump step (conditional).** `CHANGELOG.md` + version manifest found in Step 2 → append final step after all FEAT/DOC steps:
 
    ```markdown
    ### STEP-<slug>-NN: Bump version and update CHANGELOG
@@ -182,4 +182,4 @@ ______________________________________________________________________
 - [ ] Old `plans/<branch>-session-spec.md` archived to `plans/archive/` if existed
 - [ ] Final conflict sweep complete — no intra-spec contradictions, no codebase conflicts
 - [ ] All `## Open Questions` items answered, deferred with rationale, or removed
-- [ ] `<has_versioning>` true → final step is version bump + CHANGELOG; `<bump_type>` matches CLAUDE.md rules; step blocked by all preceding FEAT steps
+- [ ] `CHANGELOG.md` + version manifest present → final step is version bump + CHANGELOG; `<bump_type>` matches CLAUDE.md rules; step blocked by all preceding FEAT steps

--- a/hyperloop/skills/session-spec/SKILL.md
+++ b/hyperloop/skills/session-spec/SKILL.md
@@ -63,6 +63,8 @@ ______________________________________________________________________
 
 Read `CLAUDE.md` for ADR locations. Scan ADR dirs and relevant source dirs for existing code related to requested feature. Identify contradictions between requested and existing. **Mandatory in both modes.**
 
+**Versioning detection (same pass):** Check for `CHANGELOG.md` + version manifest (`plugin.json`, `package.json`, `pyproject.toml`, `Cargo.toml`, etc.) in the repo. If both present → set `<has_versioning>: true`. Read `CLAUDE.md` for bump-type rules (major/minor/patch criteria). Determine `<bump_type>` from those rules + nature of changes being spec'd.
+
 ### Step 3 — Single Focused Interview
 
 Max 2–3 `AskUserQuestion` calls total. Rules:
@@ -138,6 +140,21 @@ Max 2–3 `AskUserQuestion` calls total. Rules:
 
    > **Reading note for agents:** Metadata table (if present) appears **immediately after H1** and **before first `##` section**. Parsers: locate H1, scan forward collecting all `| Source Issue |` rows before `##`; none found → `source_issues` is `null`.
 
+5. **Version bump step (conditional).** `<has_versioning>` true → append final step after all FEAT/DOC steps:
+
+   ```markdown
+   ### STEP-<slug>-NN: Bump version and update CHANGELOG
+
+   > skills: hyperwork-tech-writing
+
+   **Acceptance Criteria:**
+   - [ ] Version manifest (`plugin.json` / `package.json` / etc.) bumped to next <bump_type> version per CLAUDE.md rules
+   - [ ] `CHANGELOG.md` entry added under correct version header covering all changes in this spec
+   - [ ] Project verification command exits 0
+   ```
+
+   `<bump_type>` from Step 2 detection. Step always last — blocked by all preceding FEAT steps.
+
 ### Step 6 — Final Conflict Sweep
 
 Verify: no step contradicts another; no step conflicts with codebase findings from Step 2. Conflict found → raise with user via `AskUserQuestion` and resolve before saving.
@@ -165,3 +182,4 @@ ______________________________________________________________________
 - [ ] Old `plans/<branch>-session-spec.md` archived to `plans/archive/` if existed
 - [ ] Final conflict sweep complete — no intra-spec contradictions, no codebase conflicts
 - [ ] All `## Open Questions` items answered, deferred with rationale, or removed
+- [ ] `<has_versioning>` true → final step is version bump + CHANGELOG; `<bump_type>` matches CLAUDE.md rules; step blocked by all preceding FEAT steps


### PR DESCRIPTION
## Summary

- Bumps `plugin.json` version `3.1.0` → `3.1.1`
- Adds `[3.1.1]` CHANGELOG entry documenting changes shipped in #34 (feat-reduce-sync-scope) that were missed

## Why a separate PR

Version bump was not included as a task in the feat-reduce-sync-scope session spec — planning gap. GATE check did not enforce CHANGELOG/version bump as a hard criterion.

## Test plan

- [ ] `claude plugin validate .` passes (pre-commit enforces this)
- [ ] CHANGELOG `[3.1.1]` entry accurately describes the reduce-sync-scope changes